### PR TITLE
Adding outlier rejection and new interpolation function

### DIFF
--- a/mccd/auxiliary_fun.py
+++ b/mccd/auxiliary_fun.py
@@ -668,7 +668,7 @@ def mccd_validation(mccd_model_path, testcat, apply_degradation=True,
                     for _star, _pos, _mask, _ccd_id in
                     zip(val_star_list, val_pos_list, val_mask_list,
                         val_ccd_list)]
-
+    """
     # [TL] TEST
     # Checking how many CCDs would have been rejected.
     dim_x = val_star_list[0].shape[0]
@@ -689,37 +689,38 @@ def mccd_validation(mccd_model_path, testcat, apply_degradation=True,
         # Reconstruct the PSFs
         psfs = PSF_list[k]
 
-        # Estimate noise
-        sigmas_obs = np.array([noise_estimator.estimate_noise(star)
-                        for star in stars])
+        if psfs is not None:
+            # Estimate noise
+            sigmas_obs = np.array([noise_estimator.estimate_noise(star)
+                            for star in stars])
 
-        # Window to consider the central PSF only
-        window = ~noise_estimator.window
+            # Window to consider the central PSF only
+            window = ~noise_estimator.window
 
-        # Calculate the windowed RMSE normalized by the noise level
-        rmse_sig = np.array([
-            np.sqrt(np.mean(((_mod - _obs)**2)[window])) / _sig
-            for _mod, _obs, _sig in zip(psfs, stars, sigmas_obs)
-                            ])
+            # Calculate the windowed RMSE normalized by the noise level
+            rmse_sig = np.array([
+                np.sqrt(np.mean(((_mod - _obs)**2)[window])) / _sig
+                for _mod, _obs, _sig in zip(psfs, stars, sigmas_obs)
+                                ])
 
-        # Select outlier stars
-        outlier_ids = rmse_sig >= rmse_thresh
-        num_outliers = np.sum(outlier_ids)
+            # Select outlier stars
+            outlier_ids = rmse_sig >= rmse_thresh
+            num_outliers = np.sum(outlier_ids)
 
-        # Check if the number of outliers depasses the star threshold
-        num_stars = stars.shape[0]
-        star_thresh_num = np.ceil(ccd_star_thresh * num_stars)
+            # Check if the number of outliers depasses the star threshold
+            num_stars = stars.shape[0]
+            star_thresh_num = np.ceil(ccd_star_thresh * num_stars)
 
-        print("CCD num %02d, \t %d outliers, \t%d stars,"
-                " \t%d star threshold number." % (
-                    val_ccd_list[k], num_outliers, num_stars,
-                    star_thresh_num))
+            print("CCD num %02d, \t %d outliers, \t%d stars,"
+                    " \t%d star threshold number." % (
+                        val_ccd_list[k], num_outliers, num_stars,
+                        star_thresh_num))
 
-        if num_outliers >= star_thresh_num:
-            # We have to reject the CCD
-            ccd_outliers.append(k)
-            print('\n**\nOutlier! CCD %d, \t%d outliers, \t%d total stars.' % (
-                val_ccd_list[k], num_outliers, num_stars))
+            if num_outliers > star_thresh_num:
+                # We have to reject the CCD
+                ccd_outliers.append(k)
+                print('\nOutlier! CCD %d, \t%d outliers, \t%d tot stars.' % (
+                    val_ccd_list[k], num_outliers, num_stars))
 
     # Remove all the outliers
     # for idx in sorted(ccd_outliers, reverse=True):
@@ -733,6 +734,7 @@ def mccd_validation(mccd_model_path, testcat, apply_degradation=True,
     #         del val_DEC_list[idx]
 
     # [TL] finish testing
+    """
 
     # Remove the CCDs not used for training from ALL the lists
     # Identify the None elements on a boolean list

--- a/mccd/auxiliary_fun.py
+++ b/mccd/auxiliary_fun.py
@@ -669,6 +669,60 @@ def mccd_validation(mccd_model_path, testcat, apply_degradation=True,
                     zip(val_star_list, val_pos_list, val_mask_list,
                         val_ccd_list)]
 
+    # [TL] TEST
+    # Checking how many CCDs would have been rejected.
+    dim_x = val_star_list[0].shape[0]
+    dim_y = val_star_list[0].shape[1]
+    win_rad = np.floor(np.max([dim_x, dim_y]) / 3)
+
+    ccd_star_thresh = 0.1
+    rmse_thresh = 1.25
+
+    # Calculate the observation noise
+    noise_estimator = utils.NoiseEstimator((dim_x, dim_y), win_rad)
+
+    ccd_outliers = []
+
+    for k in range(len(val_star_list)):
+        # Extract observations and reconstructions from the CCD
+        stars = utils.reg_format(val_star_list[k])
+        # Reconstruct the PSFs
+        psfs = PSF_list[k]
+
+        # Estimate noise
+        sigmas_obs = np.array([noise_estimator.estimate_noise(star)
+                        for star in stars])
+
+        # Window to consider the central PSF only
+        window = ~noise_estimator.window
+
+        # Calculate the windowed RMSE normalized by the noise level
+        rmse_sig = np.array([
+            np.sqrt(np.mean(((_mod - _obs)**2)[window])) / _sig
+            for _mod, _obs, _sig in zip(psfs, stars, sigmas_obs)
+                            ])
+
+        # Select outlier stars
+        outlier_ids = rmse_sig >= rmse_thresh
+        num_outliers = np.sum(outlier_ids)
+
+        # Check if the number of outliers depasses the star threshold
+        num_stars = stars.shape[0]
+        star_thresh_num = np.ceil(ccd_star_thresh * num_stars)
+
+        print("CCD num %02d, \t %d outliers, \t%d stars,"
+                " \t%d star threshold number." % (
+                    val_ccd_list[k], num_outliers, num_stars,
+                    star_thresh_num))
+
+        if num_outliers >= star_thresh_num:
+            # We have to reject the CCD
+            ccd_outliers.append(k)
+            print('\n**\nOutlier! CCD %d, \t%d outliers, \t%d total stars.' % (
+                val_ccd_list[k], num_outliers, num_stars))
+
+    # [TL] finish testing
+
     # Remove the CCDs not used for training from ALL the lists
     # Identify the None elements on a boolean list
     bad_ccds_bool = [psf is None for psf in PSF_list]

--- a/mccd/auxiliary_fun.py
+++ b/mccd/auxiliary_fun.py
@@ -722,15 +722,15 @@ def mccd_validation(mccd_model_path, testcat, apply_degradation=True,
                 val_ccd_list[k], num_outliers, num_stars))
 
     # Remove all the outliers
-    for idx in sorted(ccd_outliers, reverse=True):
-        del PSF_list[idx]
-        del val_pos_list[idx]
-        del val_star_list[idx]
-        del val_mask_list[idx]
-        del val_ccd_list[idx]
-        if val_RA_list is not None:
-            del val_RA_list[idx]
-            del val_DEC_list[idx]
+    # for idx in sorted(ccd_outliers, reverse=True):
+    #     del PSF_list[idx]
+    #     del val_pos_list[idx]
+    #     del val_star_list[idx]
+    #     del val_mask_list[idx]
+    #     del val_ccd_list[idx]
+    #     if val_RA_list is not None:
+    #         del val_RA_list[idx]
+    #         del val_DEC_list[idx]
 
     # [TL] finish testing
 

--- a/mccd/auxiliary_fun.py
+++ b/mccd/auxiliary_fun.py
@@ -721,6 +721,17 @@ def mccd_validation(mccd_model_path, testcat, apply_degradation=True,
             print('\n**\nOutlier! CCD %d, \t%d outliers, \t%d total stars.' % (
                 val_ccd_list[k], num_outliers, num_stars))
 
+    # Remove all the outliers
+    for idx in sorted(ccd_outliers, reverse=True):
+        del PSF_list[idx]
+        del val_pos_list[idx]
+        del val_star_list[idx]
+        del val_mask_list[idx]
+        del val_ccd_list[idx]
+        if val_RA_list is not None:
+            del val_RA_list[idx]
+            del val_DEC_list[idx]
+
     # [TL] finish testing
 
     # Remove the CCDs not used for training from ALL the lists

--- a/mccd/mccd.py
+++ b/mccd/mccd.py
@@ -591,7 +591,7 @@ class MCCD(object):
                     self.ccd_list[k], num_outliers, num_stars,
                     star_thresh_num))
 
-            if num_outliers > star_thresh_num:
+            if num_outliers >= star_thresh_num:
                 # We have to reject the CCD
                 ccd_outliers.append(k)
                 print('Removing CCD %d.' % (self.ccd_list[k]))

--- a/mccd/mccd.py
+++ b/mccd/mccd.py
@@ -140,7 +140,7 @@ class MCCD(object):
 
         # Hard-coded variables for outlier rejection
         # [TL]TODO Propagate`ccd_star_thresh` & `rmse_thresh` into config_file
-        self.ccd_star_thresh = 0.1
+        self.ccd_star_thresh = 0.15
         self.rmse_thresh = 1.25
 
         if filters is None:
@@ -590,7 +590,7 @@ class MCCD(object):
                     self.ccd_list[k], num_outliers, num_stars,
                     star_thresh_num))
 
-            if num_outliers >= star_thresh_num:
+            if num_outliers > star_thresh_num:
                 # We have to reject the CCD
                 ccd_outliers.append(k)
                 print('Removing CCD %d.' % (self.ccd_list[k]))

--- a/mccd/utils.py
+++ b/mccd/utils.py
@@ -856,3 +856,51 @@ def match_psfs(test_stars, PSFs):
     deg_PSFs *= norm_factor
 
     return deg_PSFs
+
+
+class NoiseEstimator(object):
+    """ Noise estimator.
+
+    Parameters
+    ----------
+    img_dim: tuple of int
+        Image size
+    win_rad: int
+        window radius in pixels
+
+    """
+    def __init__(self, img_dim, win_rad):
+        self.img_dim = img_dim
+        self.win_rad = win_rad
+        self.window = None
+
+        self._init_window()
+
+    def _init_window(self):
+        # Calculate window function for estimating the noise
+        # We couldn't use Galsim to estimate the moments, so we chose to work
+        # with the real center of the image (25.5,25.5)
+        # instead of using the real centroid. Also, we use 13 instead of
+        # 5 * obs_sigma, so that we are sure to cut all the flux from the star
+        self.window = np.ones(self.img_dim, dtype=bool)
+
+        mid_x = self.img_dim[0] / 2
+        mid_y = self.img_dim[1] / 2
+
+        for _x in range(self.img_dim[0]):
+            for _y in range(self.img_dim[1]):
+                if np.sqrt((_x - mid_x)**2 + (_y - mid_y)**2) <= self.win_rad:
+                    self.window[_x, _y] = False
+
+    @staticmethod
+    def sigma_mad(x):
+        r"""Compute an estimation of the standard deviation
+        of a Gaussian distribution using the robust
+        MAD (Median Absolute Deviation) estimator."""
+        return 1.4826 * np.median(np.abs(x - np.median(x)))
+
+    def estimate_noise(self, image):
+        r"""Estimate the noise level of the image."""
+
+        # Calculate noise std dev
+        return self.sigma_mad(image[self.window])


### PR DESCRIPTION
The outlier rejection is based on the chisq reconstruction error. 

The new interpolation function is in order to be compatible with Shapepipe's shape measurement pipeline definition.

French explanation not to lose track of it.
En bref, j’utilise une fenêtre circulaire qui me permet de séparer en deux parties chaque image, la partie centrale du PSF/étoile et la partie extérieur. J’utilise la partie extérieur des observations pour faire une estimation du niveau de bruit. Après, j’estime le RMSE de la partie centrale du résidu (étoile - model PSF). Si cette RMSE normalisé par le niveau de bruit de l’observation, est supérieur à un threshold (1.25 dans mon cas) on dit que l’étoile est un outlier. Dans un modele parfait, le résidu ne sera que le bruit d’observation et le RMSE normalisé sera 1. Si on a un 15% des étoiles du CCD qui sont des outliers on rejet cette CCD.